### PR TITLE
Add Electron entrypoint

### DIFF
--- a/horary78-main/frontend/main.js
+++ b/horary78-main/frontend/main.js
@@ -1,0 +1,13 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile(path.join(__dirname, 'dist/index.html'));
+}
+
+app.whenReady().then(() => {
+  spawn('python', ['../backend/app.py'], { stdio: 'inherit' });
+  createWindow();
+});

--- a/horary78-main/frontend/package.json
+++ b/horary78-main/frontend/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.0",
   "homepage": "./",
   "description": "Enhanced Traditional Horary Astrology Web Application",
+  "main": "main.js",
   "scripts": {
     "dev": "vite --mode development",
     "dev:backend": "cd ../backend && python app.py",


### PR DESCRIPTION
## Summary
- add a main.js entrypoint for Electron
- configure `package.json` to reference the new entry file

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684547a1ac6c8324933c9a852fcc5046